### PR TITLE
Add attachments to extensions

### DIFF
--- a/lib/lita/adapters/slack/message_handler.rb
+++ b/lib/lita/adapters/slack/message_handler.rb
@@ -52,14 +52,12 @@ module Lita
         def parse_attachment(a)
           lines = []
           lines << a["pretext"]
-          lines << a["author_name"]
           lines << a["title"]
-          lines << a["text"]
+          lines << a["text"] || a["fallback"]
           Array(a["fields"]).map do |field|
             lines << field["title"]
             lines << field["value"]
           end
-          lines << a["fallback"] if lines.none?
           lines.compact.map(&:strip).reject(&:empty?)
         end
 

--- a/spec/lita/adapters/slack/message_handler_spec.rb
+++ b/spec/lita/adapters/slack/message_handler_spec.rb
@@ -114,26 +114,37 @@ describe Lita::Adapters::Slack::MessageHandler, lita: true do
         end
       end
 
-      context "when the message has attach" do
+      context "when the message has attach", focus: true do
+
+
         let(:data) do
           {
-            "type" => "message",
+            "type"=>"message",
             "channel" => "C2147483705",
             "user" => "U023BECGF",
-            "text" => "Hello",
-            "attachments" => [{"text" => "attached hello"}]
+            "text" => "Text",
+            "attachments" =>
+              [{
+                "fallback" => "attached fallback",
+                "text" => "attached text",
+                "pretext"=>"attached pretext",
+                "title"=>"attached title",
+                "fields" => [{ "title" => "attached title", "value" => "attached value" }]
+               }]
           }
         end
 
-        it "recives attachment text" do
+        it "receives both serialized and raw attachments" do
           expect(Lita::Message).to receive(:new).with(
             robot,
-            "Hello\nattached hello",
+            "Text\nattached pretext\nattached title\nattached text\nattached title\nattached value",
             source
           ).and_return(message)
 
           subject.handle
+          expect(message.extensions[:slack][:attachments]).to eq(data["attachments"])
         end
+        
       end
 
       context "when the message is nil" do

--- a/spec/lita/adapters/slack/message_handler_spec.rb
+++ b/spec/lita/adapters/slack/message_handler_spec.rb
@@ -114,12 +114,10 @@ describe Lita::Adapters::Slack::MessageHandler, lita: true do
         end
       end
 
-      context "when the message has attach", focus: true do
-
-
+      context "when the message has attach" do
         let(:data) do
           {
-            "type"=>"message",
+            "type" =>"message",
             "channel" => "C2147483705",
             "user" => "U023BECGF",
             "text" => "Text",
@@ -127,8 +125,8 @@ describe Lita::Adapters::Slack::MessageHandler, lita: true do
               [{
                 "fallback" => "attached fallback",
                 "text" => "attached text",
-                "pretext"=>"attached pretext",
-                "title"=>"attached title",
+                "pretext" => "attached pretext",
+                "title" =>"attached title",
                 "fields" => [{ "title" => "attached title", "value" => "attached value" }]
                }]
           }
@@ -144,7 +142,6 @@ describe Lita::Adapters::Slack::MessageHandler, lita: true do
           subject.handle
           expect(message.extensions[:slack][:attachments]).to eq(data["attachments"])
         end
-        
       end
 
       context "when the message is nil" do


### PR DESCRIPTION
Cherrypicked and amended styling for commits made for PR https://github.com/litaio/lita-slack/pull/118 in lita-slack that is currently unmaintained. Allowing for attachments being made available in the extensions, would help us address issues we're having with Spy. Review required to see if the changes are appropriate. @Shopify/operational-excellence 