### PR TITLE
Add support for threaded messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 Add **lita-slack** to your Lita instance's Gemfile:
 
-``` ruby
+```ruby
 gem "lita-slack"
 ```
 
@@ -17,15 +17,15 @@ gem "lita-slack"
 
 ### Required attributes
 
-* `token` (String) – The bot's Slack API token. Create a bot and get its token at https://my.slack.com/services/new/lita.
+- `token` (String) – The bot's Slack API token. Create a bot and get its token at https://my.slack.com/services/new/lita.
 
 ### Optional attributes
 
-* `link_names` (Boolean) – Set to `true` to turn all Slack usernames in messages sent by Lita into links.
-* `parse` (String) – Specify the parsing mode. See https://api.slack.com/docs/formatting#parsing_modes.
-* `proxy` (String) – Specify a HTTP proxy URL. (e.g. "http://squid.example.com:3128")
-* `unfurl_links` (Boolean) – Set to `true` to automatically add previews for all links in messages sent by Lita.
-* `unfurl_media` (Boolean) – Set to `false` to prevent automatic previews for media files in messages sent by Lita.
+- `link_names` (Boolean) – Set to `true` to turn all Slack usernames in messages sent by Lita into links.
+- `parse` (String) – Specify the parsing mode. See https://api.slack.com/docs/formatting#parsing_modes.
+- `proxy` (String) – Specify a HTTP proxy URL. (e.g. "http://squid.example.com:3128")
+- `unfurl_links` (Boolean) – Set to `true` to automatically add previews for all links in messages sent by Lita.
+- `unfurl_media` (Boolean) – Set to `false` to prevent automatic previews for media files in messages sent by Lita.
 
 **Note**: When using lita-slack, the adapter will overwrite the bot's name and mention name with the values set on the server, so `config.robot.name` and `config.robot.mention_name` will have no effect.
 
@@ -35,7 +35,7 @@ Each Slack user has a unique ID that never changes even if their real name or us
 
 ### Example
 
-``` ruby
+```ruby
 Lita.configure do |config|
   config.robot.adapter = :slack
   config.robot.admins = ["U012A3BCD"]
@@ -55,16 +55,23 @@ Lita will join your default channel after initial setup. To have it join additio
 
 ## Events
 
-* `:connected` - When the robot has connected to Slack. No payload.
-* `:disconnected` - When the robot has disconnected from Slack. No payload.
-* `:slack_channel_created` - When the robot creates/updates a channel's or group's info, as directed by Slack. The payload has a single object, a `Lita::Slack::Adapters::SlackChannel` object, under the `:slack_channel` key.
-* `:slack_reaction_added` - When a reaction has been added to a previous message. The payload includes `:user` (a `Lita::User` for the sender of the message in question), `:name` (the string name of the reaction added), `:item_user` (a `Lita::User` for the user that created the original item that has been reacted to), `:item` (a hash of raw data from Slack about the message), and `:event_ts` (a string timestamp used to identify the message).
-* `:slack_reaction_removed` - When a reaction has been removed from a previous message. The payload is the same as the `:slack_reaction_added` message.
-* `:slack_user_created` - When the robot creates/updates a user's info - name, mention name, etc., as directed by Slack. The payload has a single object, a `Lita::Slack::Adapters::SlackUser` object, under the `:slack_user` key.
+- `:connected` - When the robot has connected to Slack. No payload.
+- `:disconnected` - When the robot has disconnected from Slack. No payload.
+- `:slack_channel_created` - When the robot creates/updates a channel's or group's info, as directed by Slack. The payload has a single object, a `Lita::Slack::Adapters::SlackChannel` object, under the `:slack_channel` key.
+- `:slack_reaction_added` - When a reaction has been added to a previous message. The payload includes `:user` (a `Lita::User` for the sender of the message in question), `:name` (the string name of the reaction added), `:item_user` (a `Lita::User` for the user that created the original item that has been reacted to), `:item` (a hash of raw data from Slack about the message), and `:event_ts` (a string timestamp used to identify the message).
+- `:slack_reaction_removed` - When a reaction has been removed from a previous message. The payload is the same as the `:slack_reaction_added` message.
+- `:slack_user_created` - When the robot creates/updates a user's info - name, mention name, etc., as directed by Slack. The payload has a single object, a `Lita::Slack::Adapters::SlackUser` object, under the `:slack_user` key.
 
 ## Chat service API
 
 lita-slack supports Lita 4.6's chat service API for Slack-specific functionality. You can access this API object by calling the `Lita::Robot#chat_service`. See the API docs for `Lita::Adapters::Slack::ChatService` for details about the provided methods.
+
+## Threading
+
+lita-slack supports Slack threading by default, it will reply to messages in the same context as they were created by default.
+This means it will reply in channel if a message was sent from the channel, or in thread if a message was sent from a thread.
+
+You can prepend the first line of your message with the ellipsis character `…` to start a new thread.
 
 ## API documentation
 

--- a/dev.yml
+++ b/dev.yml
@@ -3,4 +3,3 @@ name: lita-slack
 up:
   - ruby:
       version: 2.4.3
-  - railgun

--- a/dev.yml
+++ b/dev.yml
@@ -2,5 +2,5 @@ name: lita-slack
 
 up:
   - ruby:
-      version:  2.4.3
-
+      version: 2.4.3
+  - railgun

--- a/lib/lita/adapters/slack.rb
+++ b/lib/lita/adapters/slack.rb
@@ -133,7 +133,7 @@ module Lita
 
       def try_get(object, attribute)
         if object.respond_to? attribute
-          object.attribute
+          object.send(attribute)
         else
           nil
         end

--- a/lib/lita/adapters/slack.rb
+++ b/lib/lita/adapters/slack.rb
@@ -43,8 +43,8 @@ module Lita
       def send_messages(target, messages)
         api = API.new(config)
         channel = channel_for(target)
-        timestamp = target.try(:timestamp)
-        thread_ts = target.try(:thread_ts)
+        timestamp = try_get(target, :timestamp)
+        thread_ts = try_get(target, :thread_ts)
 
         strings = messages.select { |s| s.is_a?(String) }
         symbols = messages.select { |s| s.is_a?(Symbol) }
@@ -128,6 +128,14 @@ module Lita
           roster.empty? ? mpim_roster(room_id, api) : roster
         when /^D/
           im_roster room_id, api
+        end
+      end
+
+      def try_get(object, attribute)
+        if object.respond_to? attribute
+          object.attribute
+        else
+          nil
         end
       end
     end

--- a/lib/lita/adapters/slack.rb
+++ b/lib/lita/adapters/slack.rb
@@ -38,27 +38,23 @@ module Lita
         room_roster target.id, api
       end
 
-      # @param [Array] messages list of String messages or Symbol emoji reactions
+      # @param [Array] messages list of String messages
       # messages starting with the ellipsis character will start a new thread
       def send_messages(target, messages)
         api = API.new(config)
         channel = channel_for(target)
-        timestamp = try_get(target, :timestamp)
-        thread_ts = try_get(target, :thread_ts)
+        timestamp = target.timestamp if target.respond_to?(:timestamp)
+        thread_ts = target.timestamp if target.respond_to?(:timestamp)
 
-        strings = messages.select { |s| s.is_a?(String) }
-
-        if strings[0] && strings[0][0] == '…'
+        if messages[0] && messages[0][0] == '…'
           thread_ts = timestamp
-          strings[0] = strings[0][1..-1]
+          messages[0] = messages[0][1..-1]
         end
         
-        if strings.any?
-          if thread_ts
-            api.reply_in_thread(channel, strings, thread_ts)
-          else
-            api.send_messages(channel, strings)
-          end
+        if thread_ts
+          api.reply_in_thread(channel, messages, thread_ts)
+        else
+          api.send_messages(channel, messages)
         end
       end
 
@@ -123,14 +119,6 @@ module Lita
           roster.empty? ? mpim_roster(room_id, api) : roster
         when /^D/
           im_roster room_id, api
-        end
-      end
-
-      def try_get(object, attribute)
-        if object.respond_to? attribute
-          object.send(attribute)
-        else
-          nil
         end
       end
     end

--- a/lib/lita/adapters/slack.rb
+++ b/lib/lita/adapters/slack.rb
@@ -47,11 +47,6 @@ module Lita
         thread_ts = try_get(target, :thread_ts)
 
         strings = messages.select { |s| s.is_a?(String) }
-        symbols = messages.select { |s| s.is_a?(Symbol) }
-
-        symbols.each do |s|
-          api.react_with_emoji(channel, s.to_s, timestamp)
-        end if timestamp
 
         if strings[0] && strings[0][0] == '…'
           thread_ts = timestamp

--- a/lib/lita/adapters/slack/api.rb
+++ b/lib/lita/adapters/slack/api.rb
@@ -3,6 +3,7 @@ require 'faraday'
 require 'lita/adapters/slack/team_data'
 require 'lita/adapters/slack/slack_im'
 require 'lita/adapters/slack/slack_user'
+require 'lita/adapters/slack/slack_source'
 require 'lita/adapters/slack/slack_channel'
 
 module Lita
@@ -70,6 +71,16 @@ module Lita
             as_user: true,
             channel: channel_id,
             text: messages.join("\n"),
+          )
+        end
+
+        def reply_in_thread(channel_id, messages, thread_ts)
+          call_api(
+            "chat.postMessage",
+            as_user: true,
+            channel: channel_id,
+            text: messages.join("\n"),
+            thread_ts: thread_ts
           )
         end
 

--- a/lib/lita/adapters/slack/chat_service.rb
+++ b/lib/lita/adapters/slack/chat_service.rb
@@ -46,6 +46,13 @@ module Lita
         def update_attachments(channel, ts, attachments)
           api.update_attachments(channel, ts, Array(attachments))
         end
+
+        # @param channel The channel containing the thread to send the message to
+        # @param messages The messages to send to the thread
+        # @param thread_ts  The timestamp of the thread message to reply to
+        def reply_in_thread(channel, messages, thread_ts)
+          api.reply_in_thread(channel,  messages, thread_ts)
+        end
       end
     end
   end

--- a/lib/lita/adapters/slack/message_handler.rb
+++ b/lib/lita/adapters/slack/message_handler.rb
@@ -126,11 +126,13 @@ module Lita
 
         def dispatch_message(user)
           room = Lita::Room.find_by_id(channel)
-          source = Source.new(user: user, room: room || channel)
+          extensions = { timestamp: data["ts"], attachments: data["attachments"] }
+          extensions[:thread_ts] = data["thread_ts"] if data["thread_ts"]
+          source = SlackSource.new(user: user, room: room || channel, extensions: extensions)
           source.private_message! if channel && channel[0] == "D"
           message = Message.new(robot, body, source)
           message.command! if source.private_message?
-          message.extensions[:slack] = { timestamp: data["ts"], attachments: data["attachments"] }
+          message.extensions[:slack] = extensions
           log.debug("Dispatching message to Lita from #{user.id}.")
           robot.receive(message)
         end

--- a/lib/lita/adapters/slack/slack_source.rb
+++ b/lib/lita/adapters/slack/slack_source.rb
@@ -1,0 +1,25 @@
+module Lita
+  module Adapters
+    class Slack < Adapter
+      # A struct representing a Slack message source. It has access to
+      # extensions of the original message from the source, which enables
+      # reacting with emoji or replying in threads.
+      #
+      # @api public
+      class SlackSource < Lita::Source
+        def initialize(**kwargs)
+          @extensions = kwargs.delete(:extensions)
+          super(**kwargs)
+        end
+
+        def timestamp
+          @extensions[:timestamp]
+        end
+        
+        def thread_ts
+          @extensions[:thread_ts]
+        end
+      end
+    end
+  end
+end

--- a/lib/lita/adapters/slack/slack_source.rb
+++ b/lib/lita/adapters/slack/slack_source.rb
@@ -9,6 +9,7 @@ module Lita
       class SlackSource < Lita::Source
         def initialize(**kwargs)
           @extensions = kwargs.delete(:extensions)
+          @extensions ||= { }
           super(**kwargs)
         end
 

--- a/spec/lita/adapters/slack/api_spec.rb
+++ b/spec/lita/adapters/slack/api_spec.rb
@@ -579,6 +579,139 @@ describe Lita::Adapters::Slack::API do
     end
   end
 
+  describe "#reply_in_thread" do
+    let(:messages) { ["attachment text"] }
+    let(:http_response) { MultiJson.dump({ ok: true }) }
+    let(:room) { "C1234567890" }
+    let(:thread_ts) { 12346567 }
+    let(:stubs) do
+      Faraday::Adapter::Test::Stubs.new do |stub|
+        stub.post(
+          "https://slack.com/api/chat.postMessage",
+          token: token,
+          as_user: true,
+          channel: room,
+          text: messages.join("\n"),
+          thread_ts: thread_ts,
+        ) do
+          [http_status, {}, http_response]
+        end
+      end
+    end
+
+    context "with a simple text attachment" do
+      it "sends the attachment" do
+        response = subject.reply_in_thread(room, messages, thread_ts)
+
+        expect(response['ok']).to be(true)
+      end
+    end
+
+    context "with configuration" do
+      before do
+        allow(config).to receive(:link_names).and_return(true)
+      end
+
+      def stubs(postMessage_options = {})
+        Faraday::Adapter::Test::Stubs.new do |stub|
+          stub.post(
+            "https://slack.com/api/chat.postMessage",
+            token: token,
+            link_names: 1,
+            as_user: true,
+            channel: room,
+            text: messages.join("\n"),
+            thread_ts: thread_ts,
+          ) do
+            [http_status, {}, http_response]
+          end
+        end
+      end
+
+      it "sends the message with configuration" do
+        response = subject.reply_in_thread(room, messages, thread_ts)
+
+        expect(response['ok']).to be(true)
+      end
+    end
+
+    context "with a different fallback message" do
+      let(:attachment) do
+        Lita::Adapters::Slack::Attachment.new(attachment_text, fallback: fallback_text)
+      end
+      let(:fallback_text) { "fallback text" }
+
+      it "sends the attachment" do
+        response = subject.reply_in_thread(room, messages, thread_ts)
+
+        expect(response['ok']).to be(true)
+      end
+    end
+
+    context "with all the valid options" do
+      let(:attachment) do
+        Lita::Adapters::Slack::Attachment.new(attachment_text, common_hash_data)
+      end
+      let(:attachment_hash) do
+        common_hash_data.merge(fallback: attachment_text, text: attachment_text)
+      end
+      let(:common_hash_data) do
+        {
+          author_icon: "http://example.com/author.jpg",
+          author_link: "http://example.com/author",
+          author_name: "author name",
+          color: "#36a64f",
+          fields: [{
+            title: "priority",
+            value: "high",
+            short: true,
+          }, {
+            title: "super long field title",
+            value: "super long field value",
+            short: false,
+          }],
+          image_url: "http://example.com/image.jpg",
+          pretext: "pretext",
+          thumb_url: "http://example.com/thumb.jpg",
+          title: "title",
+          title_link: "http://example.com/title",
+        }
+      end
+
+      it "sends the attachment" do
+        response = subject.reply_in_thread(room, messages, thread_ts)
+
+        expect(response['ok']).to be(true)
+      end
+    end
+
+    context "with a Slack error" do
+      let(:http_response) do
+        MultiJson.dump({
+          ok: false,
+          error: 'invalid_auth'
+        })
+      end
+
+      it "raises a RuntimeError" do
+        expect { subject.reply_in_thread(room, messages, thread_ts) }.to raise_error(
+          "Slack API call to chat.postMessage returned an error: invalid_auth."
+        )
+      end
+    end
+
+    context "with an HTTP error" do
+      let(:http_status) { 422 }
+      let(:http_response) { '' }
+
+      it "raises a RuntimeError" do
+        expect { subject.reply_in_thread(room, messages, thread_ts) }.to raise_error(
+          "Slack API call to chat.postMessage failed with status code 422: ''. Headers: {}"
+        )
+      end
+    end
+  end
+
   describe "#set_topic" do
     let(:channel) { 'C1234567890' }
     let(:topic) { 'Topic' }

--- a/spec/lita/adapters/slack/api_spec.rb
+++ b/spec/lita/adapters/slack/api_spec.rb
@@ -617,7 +617,6 @@ describe Lita::Adapters::Slack::API do
           stub.post(
             "https://slack.com/api/chat.postMessage",
             token: token,
-            link_names: 1,
             as_user: true,
             channel: room,
             text: messages.join("\n"),

--- a/spec/lita/adapters/slack/message_handler_spec.rb
+++ b/spec/lita/adapters/slack/message_handler_spec.rb
@@ -490,6 +490,35 @@ describe Lita::Adapters::Slack::MessageHandler, lita: true do
       end
     end
 
+    context "with a message to create a thread" do
+      let(:data) do
+        {
+          "type" => "_message new thread",
+          "channel" => "C2147483705",
+          "user" => "U023BECGF",
+          "text" => "Hello",
+          "ts" => "1234.5678"
+        }
+      end
+      let(:message) { instance_double('Lita::Message', command!: false, extensions: {}) }
+      let(:source) { instance_double('Lita::Source', private_message?: false) }
+      let(:user) { instance_double('Lita::User', id: 'U023BECGF') }
+      let(:room) { instance_double('Lita::Room', id: "C2147483705", name: "general") }
+      let(:extensions) do { :timestamp => nil, :attachments => nil } end
+
+      before do
+        allow(Lita::User).to receive(:find_by_id).and_return(user)
+        allow(Lita::Room).to receive(:find_by_id).and_return(room)
+        allow(Lita::Adapters::Slack::SlackSource).to receive(:new).with(
+          user: user,
+          room: room,
+          extensions: extensions
+        ).and_return(source)
+        allow(Lita::Message).to receive(:new).with(robot, "Hello", source).and_return(message)
+        allow(robot).to receive(:receive).with(message)
+      end
+    end
+
     context "with a message with an unsupported subtype" do
       let(:data) do
         {
@@ -687,6 +716,9 @@ describe Lita::Adapters::Slack::MessageHandler, lita: true do
 
         subject.handle
       end
+    end
+
+    context "with a message to create a new thread" do
     end
   end
 end

--- a/spec/lita/adapters/slack/slack_source_spec.rb
+++ b/spec/lita/adapters/slack/slack_source_spec.rb
@@ -1,0 +1,36 @@
+require "spec_helper"
+
+describe Lita::Adapters::Slack::SlackSource, lita: true do
+  subject { described_class.new(room: room_source, extensions: extensions) }
+
+  let(:room_source) { Lita::Source.new(room: 'C024BE91L') }
+
+  describe "with timestamps" do
+    let(:extensions) do
+      { 
+        :timestamp => "123456.789",
+        :thread_ts => "98765.12" 
+      }
+    end
+
+    it "can read timestamp" do
+      expect(subject.timestamp).to eq("123456.789")
+    end
+
+    it "can read thread_ts" do
+      expect(subject.thread_ts).to eq("98765.12")
+    end
+  end
+
+  describe "without extensions" do
+    let(:extensions) { { } }
+
+    it "can read timestamp" do
+      expect(subject.timestamp).to eq(nil)
+    end
+
+    it "can read thread_ts" do
+      expect(subject.thread_ts).to eq(nil)
+    end
+  end
+end

--- a/spec/lita/adapters/slack_spec.rb
+++ b/spec/lita/adapters/slack_spec.rb
@@ -121,7 +121,7 @@ describe Lita::Adapters::Slack, lita: true do
     let(:user) { Lita::User.new('U023BECGF') }
     let(:user_source) { Lita::Source.new(user: user) }
     let(:private_message_source) do
-      Lita::Source.new(room: 'C024BE91L', user: user, private_message: true)
+      Lita::Adapters::Slack::SlackSource.new(room: 'C024BE91L', user: user, private_message: true)
     end
 
     describe "via the Web API" do

--- a/spec/lita/adapters/slack_spec.rb
+++ b/spec/lita/adapters/slack_spec.rb
@@ -117,7 +117,7 @@ describe Lita::Adapters::Slack, lita: true do
   end
 
   describe "#send_messages" do
-    let(:room_source) { Lita::Source.new(room: 'C024BE91L') }
+    let(:room_source) { Lita::Adapters::Slack::SlackSource.new(room: 'C024BE91L') }
     let(:user) { Lita::User.new('U023BECGF') }
     let(:user_source) { Lita::Source.new(user: user) }
     let(:private_message_source) do
@@ -136,6 +136,20 @@ describe Lita::Adapters::Slack, lita: true do
         expect(api).to receive(:send_messages).with(room_source.room, ['foo'])
 
         subject.send_messages(room_source, ['foo'])
+      end
+    end
+
+    describe "with an ellipsis" do
+      let(:room_source) { Lita::Adapters::Slack::SlackSource.new(room: 'C024BE91L', extensions: { timestamp: "12345" } ) }
+      let(:api) { instance_double('Lita::Adapters::Slack::API') }
+
+      before do
+        allow(Lita::Adapters::Slack::API).to receive(:new).with(subject.config).and_return(api)
+      end
+
+      it "sends a new threaded message" do
+        expect(api).to receive(:reply_in_thread).with(room_source.room, ['foo'], "12345")
+        subject.send_messages(room_source, ['…foo'])
       end
     end
   end


### PR DESCRIPTION
Based (copied) on the proposal from upstream: https://github.com/litaio/lita-slack/pull/123/ to add support for threaded messages.

https://api.slack.com/docs/message-threading

Threads are identified by a `thread_ts` attribute, this indicates the presence of a thread.

If the `thread_ts` _matches_ `ts`, then it's the root of the thread
If they differ, it is a reply to the thread.

I've tophatted this with shy-dev locally, and it does not require any changes from spy itself to take things into account. I also confirmed using `shy` (spy staging)

If a message is received in the main channel, spy will reply in the main channel
If a message is received in a thread, spy will reply in a thread.

I've kept the support for ellipsis to start a new thread, nothing is actively using this in spy from what I can tell, but we can switch it to use a helper (I didn't deviate much from the Proposal PR) 

## 🎩 

To tophat, switch your local spy Gemfile to use the local directory of this branch for `shopify-lita-slack`

Screenshot of threading, the first command call to shy was with the original version from package cloud, the next ones were from the new version of Lita. 

![image](https://user-images.githubusercontent.com/1833545/44874860-7db00a80-ac6a-11e8-8c0c-a820072cb4b6.png)
