### PR TITLE
Adapter run method calls a block when ready

### DIFF
--- a/lib/lita/adapters/slack.rb
+++ b/lib/lita/adapters/slack.rb
@@ -24,11 +24,11 @@ module Lita
       end
 
       # Starts the connection.
-      def run
+      def run(&block)
         return if rtm_connection
 
         @rtm_connection = RTMConnection.build(robot, config)
-        rtm_connection.run
+        rtm_connection.run(&block)
       end
 
       # Returns UID(s) in an Array or String for:

--- a/lib/lita/adapters/slack/rtm_connection.rb
+++ b/lib/lita/adapters/slack/rtm_connection.rb
@@ -45,7 +45,10 @@ module Lita
               websocket_options.merge(options)
             )
 
-            websocket.on(:open) { log.debug("Connected to the Slack Real Time Messaging API.") }
+            websocket.on(:open) do
+              log.debug("Connected to the Slack Real Time Messaging API.")
+              yield if block_given?
+            end
             websocket.on(:message) { |event| receive_message(event) }
             websocket.on(:close) do |event|
               log.info("Disconnected from Slack.")


### PR DESCRIPTION
Adapter run method calls a block when ready. This allows us to only watch the outbound queue when the rtm connection is ready.