### PR TITLE
Send DMs via API and not websocket

### DIFF
--- a/lib/lita/adapters/slack.rb
+++ b/lib/lita/adapters/slack.rb
@@ -51,7 +51,7 @@ module Lita
           thread_ts = timestamp
           messages[0] = messages[0][1..-1]
         end
-        
+
         if thread_ts
           api.reply_in_thread(channel, messages, thread_ts)
         else
@@ -77,11 +77,7 @@ module Lita
       attr_reader :rtm_connection
 
       def channel_for(target)
-        if target.private_message?
-          rtm_connection.im_for(target.user.id)
-        else
-          target.room
-        end
+        target.room
       end
 
       def channel_roster(room_id, api)


### PR DESCRIPTION
Slack treats DMs and channels the same now, so we don't need to differentiate them anymore.