### PR TITLE
Revert "Send DMs via API and not websocket"

### DIFF
--- a/lib/lita/adapters/slack.rb
+++ b/lib/lita/adapters/slack.rb
@@ -51,7 +51,7 @@ module Lita
           thread_ts = timestamp
           messages[0] = messages[0][1..-1]
         end
-
+        
         if thread_ts
           api.reply_in_thread(channel, messages, thread_ts)
         else
@@ -77,7 +77,11 @@ module Lita
       attr_reader :rtm_connection
 
       def channel_for(target)
-        target.room
+        if target.private_message?
+          rtm_connection.im_for(target.user.id)
+        else
+          target.room
+        end
       end
 
       def channel_roster(room_id, api)


### PR DESCRIPTION
Reverts Shopify/lita-slack#15

This does not work for webhooks lita-slack receives because it comes with a user but not with a channel, therefore channel is nil and cannot send the direct message to the user. However when it is user initiated, it does come with a channel id and therefore can work appropriately. A new commit will come with a fix.