### PR TITLE
Move where block is yielded at connection

### DIFF
--- a/lib/lita/adapters/slack.rb
+++ b/lib/lita/adapters/slack.rb
@@ -28,7 +28,9 @@ module Lita
         return if rtm_connection
 
         @rtm_connection = RTMConnection.build(robot, config)
-        rtm_connection.run(&block)
+
+        yield if block_given?
+        rtm_connection.run
       end
 
       # Returns UID(s) in an Array or String for:
@@ -51,7 +53,7 @@ module Lita
           thread_ts = timestamp
           messages[0] = messages[0][1..-1]
         end
-        
+
         if thread_ts
           api.reply_in_thread(channel, messages, thread_ts)
         else

--- a/lib/lita/adapters/slack/rtm_connection.rb
+++ b/lib/lita/adapters/slack/rtm_connection.rb
@@ -47,7 +47,6 @@ module Lita
 
             websocket.on(:open) do
               log.debug("Connected to the Slack Real Time Messaging API.")
-              yield if block_given?
             end
             websocket.on(:message) { |event| receive_message(event) }
             websocket.on(:close) do |event|


### PR DESCRIPTION
The block was yielded at the connection open because we wanted messages to only be processed when the websocket was already open. All messages are sent via the API anyway, we just go through the RTMConnection object to get the user->channel mapping, which is already populated by rtm_start data and doesn't depend on the websockets connection being up.

This will also allow private messages to be sent without issues even when the RTM connection is not up anymore.