### PR TITLE
Bump to v2.0.1

### DIFF
--- a/lita-slack.gemspec
+++ b/lita-slack.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |spec|
   spec.name          = "shopify-lita-slack"
-  spec.version       = "2.0.0"
+  spec.version       = "2.0.1"
   spec.authors       = ["Ryan Brushett", "Ridwan Sharif"]
   spec.description   = %q{Lita adapter for Slack.}
   spec.summary       = %q{Lita adapter for Slack.}


### PR DESCRIPTION
Release adding the following fix: https://github.com/Shopify/lita-slack/pull/18.