### PR TITLE
Log rtm start connection to debug lost websocket

### DIFF
--- a/lib/lita/adapters/slack.rb
+++ b/lib/lita/adapters/slack.rb
@@ -26,10 +26,11 @@ module Lita
       # Starts the connection.
       def run(&block)
         return if rtm_connection
-
+        Lita.logger.debug("Starting to build RTM connection")
         @rtm_connection = RTMConnection.build(robot, config)
-
+        Lita.logger.debug("Done building RTM connection")
         yield if block_given?
+        Lita.logger.debug("Done yielding block & will start running the rtm connection")
         rtm_connection.run
       end
 

--- a/lib/lita/adapters/slack/api.rb
+++ b/lib/lita/adapters/slack/api.rb
@@ -102,9 +102,10 @@ module Lita
         end
 
         def rtm_start
+          Lita.logger.debug("Starting `rtm_start` method")
           response_data = call_api("rtm.start")
-
-          TeamData.new(
+          Lita.logger.debug("Started building TeamData")
+          team_data = TeamData.new(
             SlackIM.from_data_array(response_data["ims"]),
             SlackUser.from_data(response_data["self"]),
             SlackUser.from_data_array(response_data["users"]),
@@ -112,6 +113,9 @@ module Lita
               SlackChannel.from_data_array(response_data["groups"]),
             response_data["url"],
           )
+          Lita.logger.debug("Finished building TeamData")
+          Lita.logger.debug("Finishing method `rtm_start`")
+          team_data
         end
 
         private
@@ -121,13 +125,14 @@ module Lita
         attr_reader :post_message_config
 
         def call_api(method, post_data = {})
+          Lita.logger.debug("Starting request to Slack API with rtm.start")
           response = connection.post(
             "https://slack.com/api/#{method}",
             { token: config.token }.merge(post_data)
           )
-
+          Lita.logger.debug("Finished request to Slack API rtm.start")
           data = parse_response(response, method)
-
+          Lita.logger.debug("Finished parsing rtm.start response")
           raise "Slack API call to #{method} returned an error: #{data["error"]}." if data["error"]
 
           data

--- a/lib/lita/adapters/slack/rtm_connection.rb
+++ b/lib/lita/adapters/slack/rtm_connection.rb
@@ -24,12 +24,16 @@ module Lita
         def initialize(robot, config, team_data)
           @robot = robot
           @config = config
+          Lita.logger.debug("Before IMMapping")
           @im_mapping = IMMapping.new(API.new(config), team_data.ims)
+          Lita.logger.debug("After IMMapping")
           @websocket_url = team_data.websocket_url
           @robot_id = team_data.self.id
-
+          Lita.logger.debug("Start UserCreator")
           UserCreator.create_users(team_data.users, robot, robot_id)
+          Lita.logger.debug("Starting RoomCreator")
           RoomCreator.create_rooms(team_data.channels, robot)
+          Lita.logger.debug("Finished RoomCreator")
         end
 
         def im_for(user_id)


### PR DESCRIPTION
We have been seeing `Error with code 1 received from Slack: Socket URL has expired` when connecting the websocket. Adding more robust logging so we can better determine where this time is being spent so we can improve it in an upcoming PR.