### PR TITLE
Create Users & Rooms after connecting to websocket

### DIFF
--- a/lib/lita/adapters/slack.rb
+++ b/lib/lita/adapters/slack.rb
@@ -28,10 +28,9 @@ module Lita
         return if rtm_connection
         Lita.logger.debug("Starting to build RTM connection")
         @rtm_connection = RTMConnection.build(robot, config)
+
         Lita.logger.debug("Done building RTM connection")
-        yield if block_given?
-        Lita.logger.debug("Done yielding block & will start running the rtm connection")
-        rtm_connection.run
+        rtm_connection.run(&block)
       end
 
       # Returns UID(s) in an Array or String for:

--- a/lib/lita/adapters/slack/rtm_connection.rb
+++ b/lib/lita/adapters/slack/rtm_connection.rb
@@ -17,7 +17,8 @@ module Lita
 
         class << self
           def build(robot, config)
-            new(robot, config, API.new(config).rtm_start)
+            team_data = API.new(config).rtm_start
+            new(robot, config, team_data)
           end
         end
 
@@ -29,11 +30,9 @@ module Lita
           Lita.logger.debug("After IMMapping")
           @websocket_url = team_data.websocket_url
           @robot_id = team_data.self.id
-          Lita.logger.debug("Start UserCreator")
-          UserCreator.create_users(team_data.users, robot, robot_id)
-          Lita.logger.debug("Starting RoomCreator")
-          RoomCreator.create_rooms(team_data.channels, robot)
-          Lita.logger.debug("Finished RoomCreator")
+
+          @slack_users = team_data.users
+          @slack_channels = team_data.channels
         end
 
         def im_for(user_id)
@@ -51,6 +50,12 @@ module Lita
 
             websocket.on(:open) do
               log.debug("Connected to the Slack Real Time Messaging API.")
+              yield if block_given?
+              log.debug("Inserting #{slack_users.size} users")
+              UserCreator.create_users(slack_users, robot, robot_id)
+              log.debug("Inserting #{slack_channels.size} channels")
+              RoomCreator.create_rooms(slack_channels, robot)
+              log.debug("Done inserting channels.")
             end
             websocket.on(:message) { |event| receive_message(event) }
             websocket.on(:close) do |event|
@@ -88,6 +93,8 @@ module Lita
         attr_reader :robot_id
         attr_reader :websocket
         attr_reader :websocket_url
+        attr_reader :slack_users
+        attr_reader :slack_channels
 
         def log
           Lita.logger

--- a/spec/lita/adapters/slack/rtm_connection_spec.rb
+++ b/spec/lita/adapters/slack/rtm_connection_spec.rb
@@ -45,18 +45,6 @@ describe Lita::Adapters::Slack::RTMConnection, lita: true do
     it "constructs a new RTMConnection with the results of rtm.start data" do
       expect(described_class.build(robot, config)).to be_an_instance_of(described_class)
     end
-
-    it "creates users with the results of rtm.start data" do
-      expect(Lita::Adapters::Slack::UserCreator).to receive(:create_users)
-
-      described_class.build(robot, config)
-    end
-
-    it "creates rooms with the results of rtm.start data" do
-      expect(Lita::Adapters::Slack::RoomCreator).to receive(:create_rooms)
-
-      described_class.build(robot, config)
-    end
   end
 
   describe "#im_for" do
@@ -96,6 +84,15 @@ describe Lita::Adapters::Slack::RTMConnection, lita: true do
         with_websocket(subject, queue) do |websocket|
           expect(websocket).to be_an_instance_of(Faye::WebSocket::Client)
         end
+      end
+    end
+
+    it 'creates users and rooms on websocket open' do
+      expect(Lita::Adapters::Slack::RoomCreator).to receive(:create_rooms)
+      expect(Lita::Adapters::Slack::UserCreator).to receive(:create_users)
+      with_websocket(subject, queue) do |websocket|
+        websocket.emit(:open)
+        expect(websocket).to be_an_instance_of(Faye::WebSocket::Client)
       end
     end
 


### PR DESCRIPTION
We have noticed that users and channels were taking a long time to get created which was likely leading to the `Socket URL has expired` error we were seeing when connecting the Slack websocket. The user and room creation takes ~28secs in development however the window between getting the websocket URL and connecting to it is 30 seconds (cc. https://api.slack.com/methods/rtm.start, where “These URLs are only valid for 30 seconds, so connect quickly!“), which we might have easily gone over if we are in a busy node or during busy times where the responses might take longer than that to trickle in.

Moving the user creation and room creation to happen only once we  secured the websocket connection. Yielding the block passed to the run  only when the connection is open also guarantees that messages can be processed. The block being passed works even before the rooms and users
are created because most users and rooms are already in Redis and it uses the API for fetching any missing channels and/or users when it can't find them.

Also added more descriptive logging so we can see more details and timing into the different actions.