### PR TITLE
Add support for ephemeral message and attachements.

### DIFF
--- a/lib/lita/adapters/slack/api.rb
+++ b/lib/lita/adapters/slack/api.rb
@@ -74,6 +74,27 @@ module Lita
           )
         end
 
+        def send_ephemeral_attachments(room_or_user, user, attachments)
+          call_api(
+              "chat.postEphemeral",
+              as_user: true,
+              channel: room_or_user.id,
+              user: user.id,
+              attachments: MultiJson.dump(attachments.map(&:to_hash)),
+              )
+        end
+
+        def send_ephemeral_messages(room_or_user, user, messages)
+          call_api(
+              "chat.postEphemeral",
+              **post_message_config,
+              as_user: true,
+              channel: room_or_user.id,
+              user: user.id,
+              text: messages.join("\n"),
+              )
+        end
+
         def reply_in_thread(channel_id, messages, thread_ts)
           call_api(
             "chat.postMessage",

--- a/lib/lita/adapters/slack/chat_service.rb
+++ b/lib/lita/adapters/slack/chat_service.rb
@@ -24,6 +24,26 @@ module Lita
         end
         alias_method :send_attachment, :send_attachments
 
+        # @param target [Lita::Room, Lita::User] A room or user object indicating where the
+        #   attachment should be sent.
+        # @param user Lita::User A user object indicating whom should receive the ephemeral message.
+        # @param attachments [Attachment, Array<Attachment>] An {Attachment} or array of {Attachment}s to send.
+        # @return [void]
+        def send_ephemeral_attachments(target, user, attachments)
+          api.send_ephemeral_attachments(target, user, Array(attachments))
+        end
+        alias_method :send_ephemeral_attachment, :send_ephemeral_attachments
+
+        # @param target [Lita::Room, Lita::User] A room or user object indicating where the
+        #   attachment should be sent.
+        # @param user Lita::User A user object indicating whom should receive the ephemeral message.
+        # @param messages [String, Array<String>] A {String} or array of {String}s to send.
+        # @return [void]
+        def send_ephemeral_messages(target, user, messages)
+          api.send_ephemeral_messages(target, user, Array(messages))
+        end
+        alias_method :send_ephemeral_message, :send_ephemeral_messages
+
         # @param dialog The dialog to be shown to the user
         # @param trigger_id The trigger id of a slash command request URL or interactive message
         # @return [void]

--- a/spec/lita/adapters/slack/chat_service_spec.rb
+++ b/spec/lita/adapters/slack/chat_service_spec.rb
@@ -6,6 +6,7 @@ describe Lita::Adapters::Slack::ChatService, lita: true do
   let(:adapter) { Lita::Adapters::Slack.new(robot) }
   let(:robot) { Lita::Robot.new(registry) }
   let(:room) { Lita::Room.new("C2147483705") }
+  let(:user) { Lita::User.new('U023BECGF') }
 
   before do
     registry.register_adapter(:slack, Lita::Adapters::Slack)
@@ -24,6 +25,38 @@ describe Lita::Adapters::Slack::ChatService, lita: true do
       expect(subject.api).to receive(:send_attachments).with(room, [attachment])
 
       subject.send_attachment(room, attachment)
+    end
+  end
+
+  describe "#send_ephemeral_attachments" do
+    let(:attachment) { Lita::Adapters::Slack::Attachment.new("attachment text") }
+
+    it "can send an ephemeral text attachment" do
+      expect(subject.api).to receive(:send_ephemeral_attachments).with(room, user, [attachment])
+
+      subject.send_ephemeral_attachments(room, user, [attachment])
+    end
+
+    it "is aliased as send_ephemeral_attachment" do
+      expect(subject.api).to receive(:send_ephemeral_attachments).with(room, user, [attachment])
+
+      subject.send_ephemeral_attachment(room, user, [attachment])
+    end
+  end
+
+  describe "#send_ephemeral_messages" do
+    let(:attachment) { Lita::Adapters::Slack::Attachment.new("attachment text") }
+
+    it "can send an ephemeral message" do
+      expect(subject.api).to receive(:send_ephemeral_messages).with(room, user, ['foo'])
+
+      subject.send_ephemeral_messages(room, user, ['foo'])
+    end
+
+    it "is aliased as send_ephemeral_message" do
+      expect(subject.api).to receive(:send_ephemeral_messages).with(room, user, ['foo'])
+
+      subject.send_ephemeral_message(room, user, ['foo'])
     end
   end
 end


### PR DESCRIPTION
I followed the pattern used for send_attachments to introduce support for ephemeral message and attachments (https://api.slack.com/methods/chat.postEphemeral).

See https://api.slack.com/messaging/managing#ephemeral for a description of what an ephemeral message is.