### PR TITLE
Fix Travis CI build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,11 +2,11 @@ language: ruby
 sudo: false
 cache: bundler
 rvm:
-  - "2.0"
+  - "2.4"
 script: bundle exec rake
 before_install:
   - gem update --system
-  - gem update bundler
+  - gem install bundler -v 1.3
 services:
   - redis-server
 branches:


### PR DESCRIPTION
We have been using Ruby 2.4+ all along for development and deployment, so this is just adjusting CI to match that.

This is fixing the build, which is now broken for all new PRs ([example](https://github.com/Shopify/lita-slack/pull/22)).