### PR TITLE
Validate request signature and prevent replay attacks

### DIFF
--- a/lib/lita/adapters/slack.rb
+++ b/lib/lita/adapters/slack.rb
@@ -8,6 +8,7 @@ module Lita
     class Slack < Adapter
       # Required configuration attributes.
       config :token, type: String, required: true
+      config :signing_secret, type: String, required: true
       config :proxy, type: String
       config :parse, type: [String]
       config :link_names, type: [true, false]

--- a/lib/lita/http_callback.rb
+++ b/lib/lita/http_callback.rb
@@ -35,7 +35,7 @@ module Lita
     def compute_hash_sha256(env)
       timestamp = env['HTTP_X_SLACK_REQUEST_TIMESTAMP']
       payload = "#{VERSION_NUMBER}:#{timestamp}:#{request_body(env)}"
-      "#{VERSION_NUMBER}=#{OpenSSL::HMAC.hexdigest('SHA256', slack_signing_secret, payload)}"
+      "#{VERSION_NUMBER}=#{OpenSSL::HMAC.hexdigest('SHA256', slack_signing_secret(env["lita.robot"]), payload)}"
     end
 
     def request_body(env)
@@ -44,8 +44,8 @@ module Lita
       env['rack.input'].string
     end
 
-    def slack_signing_secret
-      @slack_signing_secret ||= ENV['SLACK_SIGNING_SECRET']
+    def slack_signing_secret(config)
+      config.adapters.slack.signing_secret
     end
 
     def unauthorized_response

--- a/lib/lita/http_callback.rb
+++ b/lib/lita/http_callback.rb
@@ -1,0 +1,55 @@
+module Lita
+  class HTTPCallback
+    old_call = instance_method(:call)
+    define_method(:call) do |env|
+      return unauthorized_response unless valid_request?(env)
+
+      old_call.bind(self).call(env)
+    end
+
+    private
+
+    VERSION_NUMBER = 'v0'.freeze
+    FIVE_MINUTES = 5 * 30
+
+    def valid_request?(env)
+      return false if missing_signature_or_request_timestamp?(env)
+      return false if request_expired?(env['HTTP_X_SLACK_REQUEST_TIMESTAMP'])
+      return false unless valid_signature?(env)
+
+      true
+    end
+
+    def missing_signature_or_request_timestamp?(env)
+      !(env['HTTP_X_SLACK_SIGNATURE'] && env['HTTP_X_SLACK_REQUEST_TIMESTAMP'])
+    end
+
+    def valid_signature?(env)
+      Rack::Utils.secure_compare(compute_hash_sha256(env), env['HTTP_X_SLACK_SIGNATURE'])
+    end
+
+    def request_expired?(timestamp)
+      (Time.now.utc.to_i - timestamp.to_i).abs > FIVE_MINUTES
+    end
+
+    def compute_hash_sha256(env)
+      timestamp = env['HTTP_X_SLACK_REQUEST_TIMESTAMP']
+      payload = "#{VERSION_NUMBER}:#{timestamp}:#{request_body(env)}"
+      "#{VERSION_NUMBER}=#{OpenSSL::HMAC.hexdigest('SHA256', slack_signing_secret, payload)}"
+    end
+
+    def request_body(env)
+      return '' unless env['rack.input']
+
+      env['rack.input'].string
+    end
+
+    def slack_signing_secret
+      @slack_signing_secret ||= ENV['SLACK_SIGNING_SECRET']
+    end
+
+    def unauthorized_response
+      Rack::Response.new([], 401).finish
+    end
+  end
+end

--- a/lib/lita/http_callback.rb
+++ b/lib/lita/http_callback.rb
@@ -35,7 +35,7 @@ module Lita
     def compute_hash_sha256(env)
       timestamp = env['HTTP_X_SLACK_REQUEST_TIMESTAMP']
       payload = "#{VERSION_NUMBER}:#{timestamp}:#{request_body(env)}"
-      "#{VERSION_NUMBER}=#{OpenSSL::HMAC.hexdigest('SHA256', slack_signing_secret(env["lita.robot"]), payload)}"
+      "#{VERSION_NUMBER}=#{OpenSSL::HMAC.hexdigest('SHA256', slack_signing_secret(env['lita.robot']), payload)}"
     end
 
     def request_body(env)
@@ -44,8 +44,8 @@ module Lita
       env['rack.input'].string
     end
 
-    def slack_signing_secret(config)
-      config.adapters.slack.signing_secret
+    def slack_signing_secret(robot)
+      robot.config.adapters.slack.signing_secret
     end
 
     def unauthorized_response

--- a/lib/shopify-lita-slack.rb
+++ b/lib/shopify-lita-slack.rb
@@ -1,4 +1,5 @@
 require "lita"
+require_relative "lita/http_callback"
 
 Lita.load_locales Dir[File.expand_path(
   File.join("..", "..", "locales", "*.yml"), __FILE__

--- a/spec/lita/http_callback_spec.rb
+++ b/spec/lita/http_callback_spec.rb
@@ -1,0 +1,76 @@
+require "spec_helper"
+require_relative '../../lib/lita/http_callback'
+
+describe Lita::HTTPCallback do
+
+  let(:lita_robot) { double('lita_robot') }
+  let(:http_callback) { Lita::HTTPCallback.new nil, nil }
+  let(:config) { Lita::Adapters::Slack.configuration_builder.build }
+
+  before do
+    config.signing_secret = '46277e8f4e9d54febae94252ae3c306a'
+    allow(lita_robot).to receive_message_chain('config.adapters.slack').and_return(config)
+    allow_any_instance_of(Rack::Request).to receive(:head?).and_return(true)
+  end
+
+  context 'Request has a valid signature and hasn\'t expired yet' do
+    it 'returns 204' do
+      expect(http_callback.call(build_request).first).to eq(204)
+    end
+  end
+
+  context 'Request Timestamp has expired 5 minutes ago' do
+    it 'returns 401' do
+      expect(http_callback.call(build_request(request_timestamp: timestamp - FIVE_MINUTES)).first).to eq(401)
+    end
+  end
+
+  context 'Request has an invalid signature' do
+    it 'returns 401' do
+      expect(http_callback.call(build_request(request_signature: 'invalid signature')).last.status).to eq(401)
+    end
+  end
+
+  context 'Request is missing request signature' do
+    it 'returns 401' do
+      expect(http_callback.call(build_request(request_signature: nil)).last.status).to eq(401)
+    end
+  end
+
+  context 'Request is missing request timestamp' do
+    it 'returns 401' do
+      expect(http_callback.call(build_request(request_timestamp: nil)).last.status).to eq(401)
+    end
+  end
+
+  context 'Request is missing request timestamp and signature' do
+    it 'returns 401' do
+      expect(http_callback.call(build_request(request_signature: nil, request_timestamp: nil)).last.status).to eq(401)
+    end
+  end
+
+  private
+
+  FIVE_MINUTES = 5 * 60
+
+  def build_request(request_body: rack_input, request_signature: signature, request_timestamp: timestamp)
+    {
+      'rack.input' => request_body,
+      'HTTP_X_SLACK_SIGNATURE' => request_signature,
+      'HTTP_X_SLACK_REQUEST_TIMESTAMP' => request_timestamp,
+      'lita.robot' => lita_robot
+    }
+  end
+
+  def timestamp
+    @timestamp ||= Time.now.utc.to_i
+  end
+
+  def signature
+    "v0=#{OpenSSL::HMAC.hexdigest('SHA256', config.signing_secret, "v0:#{timestamp}:SomePayload")}"
+  end
+
+  def rack_input
+    @rack_input ||= StringIO.new('SomePayload')
+  end
+end


### PR DESCRIPTION
## What is the problem you are trying to solve?

All incoming requests from slack include `X-Slack-Request-Timestamp` and `X-Slack-Signature` headers which can be used to check the integrity of the request and prevent replay attacks.
Unfortunately currently incoming requests are not being verified. This allows anyone to send requests to any app using lita-slack

## What are you trying to accomplish with this PR?

The class `HTTPCallback` is responsible for handling incoming requests and dispatching them to the correct class through the `#call` method. The solution to the problem is to monkey patch the `HTTPCallback#call` method and verify the request signature and the time it was sent. If the request has a valid signature and the request timestamp is less than **5 minutes** since it was sent then we call `super`. To read more about verifying incoming  [Slack API docs](https://api.slack.com/docs/verifying-requests-from-slack)

## Setup
### Create a slack app
1. Create the app by heading to [Slack API](https://api.slack.com/), click on **Start Building** and fill in the form to create a slack app
2. Copy the **Signing Secret** by going to **Basic Information** and Under App Credentials you should see **Signing Secret** there.
3. Create a bot by going to Bot Users under Features in the sidebar, click on **Add a Bot User** and give the bot a name.
<img width="1100" alt="Slack_API__Applications___Shopifysandbox2_Slack" src="https://user-images.githubusercontent.com/13983801/57095133-1dcda000-6ce0-11e9-9505-59cec7ff5e58.png">

4. Go to **OAuth & Permissions** and install the app to a workspace
<img width="1098" alt="Slack_API__Applications___Shopifysandbox2_Slack" src="https://user-images.githubusercontent.com/13983801/57094886-8d8f5b00-6cdf-11e9-9331-c49451939050.png">
5. After the app is installed you should be redirected back to **OAuth & Permissions** and should see **Bot User OAuth Access Token** that's your SLACK_TOKEN

### Setup lita slack bot
1. Create a `Gemfile`

```rb
source 'https://rubygems.org'

gem 'lita'
gem 'shopify-lita-slack', path: '~/src/github.com/Shopify/lita-slack' # The path to where the repo is
```

2. Create a `app.rb`

```ruby
# app.rb

module Lita
  class App < Handler
    http.post '/', :events

    def events(request, response)
      params = JSON.parse(request.body.read)
      if params['type'] == 'url_verification'
        response.headers['Content-Type'] = 'application/json'
        response.write(challenge: params['challenge'])
      end
      puts params
      response.status = 200
      response.finish
    end
  end
end

Lita.configure do |config|
  I18n.locale = :en

  config.robot.name = 'bot'
  config.robot.log_level = :info
  config.robot.adapter = :slack

  config.adapters.slack.signing_secret = ENV['SLACK_SIGNING_SECRET']
  config.adapters.slack.token = ENV['SLACK_TOKEN']

  config.http.port = 8000

  Lita.register_handler(Lita::App)
end
```

3. run `bundle install` to install the gems
4. run the following command to launch the lita slack bot

```sh
export REDIS_URL="YOUR REDIS URL"; SLACK_SIGNING_SECRET="YOUR SLACK SIGNING SECRET"; export SLACK_TOKEN="YOUR SLACK TOKEN"; bundle exec lita -c app.rb
```

5. run ngrok `ngrok http 8000`

6. Go back to **Your app settings** and under **Event Subscriptions**
    - Paste your ngrok https forwarding url into the **Request URL**
    - Under **Subscribe to Bot Events** click on **Add Bot User Event** and add `message.im`
    - Finally click on **Save Changes**

## How to 🎩 this PR?
- Find the bot on slack and type anything. It should print a json blob in your command line.
- Find the request on ngrok by going to [ngrok](http://127.0.0.1:4040) and then click on raw
- copy the request body and the following headers `X-Slack-Request-Timestamp` and `X-Slack-Signature`
- Now if you put everything to the following curl command and run it you should get a 200 status code
```sh
curl -i -X POST "ngrok https forwarding url" \
-H 'X-Slack-Request-Timestamp: your timestamp here' \
-H 'X-Slack-Signature: your signature here' \
-d @- <<EOF
PASTE YOUR REQUEST BODY HERE
EOF
```

- [ ] Check that signatures are validated by changing either the request body or the signature and you should get a 401
- [ ] Check that requests can't be played after 5 minutes by replaying a request that is older than 5 minutes. You can replay the request from the ngrok dashboard by click on replay and you should see a status code of 401