### PR TITLE
Try to enforce bundler 1.17.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ rvm:
 script: bundle exec rake
 before_install:
   - gem update --system
-  - gem install bundler -v 1.3
+  - gem install bundler -v 1.17.3
 services:
   - redis-server
 branches:

--- a/dev.yml
+++ b/dev.yml
@@ -3,6 +3,7 @@ name: lita-slack
 up:
   - ruby:
       version: 2.4.3
+  - bundler
   - railgun
 
 commands:

--- a/shipit.yml
+++ b/shipit.yml
@@ -1,5 +1,5 @@
 deploy:
   override:
-    - gem install bundler -v 1.17.3
+    - gem install bundler -v 1.3
     - bundle exec rake build
     - bundle exec package_cloud push shopify/gems pkg/*.gem


### PR DESCRIPTION
Follow-up to https://github.com/Shopify/lita-slack/pull/24. I don't know if this is a good fix - essentially I'm trying to avoid the bundler version issues we're getting in Shipit (described in the PR linked above).