### PR TITLE
Reconnect when Slack closes the websocket

### DIFF
--- a/lib/lita/adapters/slack/rtm_connection.rb
+++ b/lib/lita/adapters/slack/rtm_connection.rb
@@ -64,7 +64,8 @@ module Lita
               log.info("Disconnected from Slack.")
               log.info(event.code)
               log.info(event.reason)
-              EventLoop.safe_stop
+              log.info("Trying to reconnect...")
+              self.run(queue, options)
             end
             websocket.on(:error) { |event| log.debug("WebSocket error: #{event.message}") }
 

--- a/spec/lita/adapters/slack/rtm_connection_spec.rb
+++ b/spec/lita/adapters/slack/rtm_connection_spec.rb
@@ -121,17 +121,6 @@ describe Lita::Adapters::Slack::RTMConnection, lita: true do
       # the WebSocket.
       subject.send(:receive_message, event)
     end
-
-    context "when the WebSocket is closed from outside" do
-      it "shuts down the reactor" do
-        with_websocket(subject, queue) do |websocket|
-          sleep 0.5 # intermittent test
-          websocket.close
-          expect(EM.stopping?).to be_truthy
-        end
-      end
-    end
-
   end
 
   describe "#send_messages" do


### PR DESCRIPTION
Slack disconnects every 8 hours, which causes a restart on the master node. This prevents it from happening (tested in staging).