### PR TITLE
Add Message Deleted and Changed Handlers

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,8 @@ Lita will join your default channel after initial setup. To have it join additio
 - `:slack_reaction_added` - When a reaction has been added to a previous message. The payload includes `:user` (a `Lita::User` for the sender of the message in question), `:name` (the string name of the reaction added), `:item_user` (a `Lita::User` for the user that created the original item that has been reacted to), `:item` (a hash of raw data from Slack about the message), and `:event_ts` (a string timestamp used to identify the message).
 - `:slack_reaction_removed` - When a reaction has been removed from a previous message. The payload is the same as the `:slack_reaction_added` message.
 - `:slack_user_created` - When the robot creates/updates a user's info - name, mention name, etc., as directed by Slack. The payload has a single object, a `Lita::Slack::Adapters::SlackUser` object, under the `:slack_user` key.
+- `:message_deleted` - When a message is deleted. The payload contains a message hash for the deleted message under the `"previous_message"` key.
+- `:message_changed` - When a message is edited. The payload contains a message hash for the orignal message under the `"previous_message"` key and a message hash for the edited message under the `"message"` key.
 
 ## Chat service API
 

--- a/lib/lita/adapters/slack/message_handler.rb
+++ b/lib/lita/adapters/slack/message_handler.rb
@@ -171,7 +171,14 @@ module Lita
 
           return if from_self?(user)
 
-          dispatch_message(user)
+          case data["subtype"]
+          when "message_deleted"
+            robot.trigger(:message_deleted, data)
+          when "message_changed"
+            robot.trigger(:message_changed, data)
+          else
+            dispatch_message(user)
+          end
         end
 
         def handle_reaction
@@ -212,7 +219,7 @@ module Lita
         end
 
         # Types of messages Lita should dispatch to handlers.
-        SUPPORTED_MESSAGE_SUBTYPES = %w(me_message)
+        SUPPORTED_MESSAGE_SUBTYPES = %w(me_message message_deleted message_changed)
 
         def supported_subtype?
           subtype = data["subtype"]

--- a/spec/lita/adapters/slack/message_handler_spec.rb
+++ b/spec/lita/adapters/slack/message_handler_spec.rb
@@ -534,6 +534,44 @@ describe Lita::Adapters::Slack::MessageHandler, lita: true do
       end
     end
 
+    context "with a message with message_deleted subtype" do
+      let(:data) do
+        {
+          "type" => "message",
+          "subtype" => "message_deleted"
+        }
+      end
+
+      before do
+        allow(robot).to receive(:trigger).with(:message_deleted, data)
+      end
+
+      it "triggers the message_deleted event" do
+        expect(robot).to receive(:trigger).with(:message_deleted, data)
+
+        subject.handle
+      end
+    end
+
+    context "with a message with message_changed subtype" do
+      let(:data) do
+        {
+          "type" => "message",
+          "subtype" => "message_changed"
+        }
+      end
+
+      before do
+        allow(robot).to receive(:trigger).with(:message_changed, data)
+      end
+
+      it "triggers the message_changed event" do
+        expect(robot).to receive(:trigger).with(:message_changed, data)
+
+        subject.handle
+      end
+    end
+
     context "with a message from slackbot" do
       let(:data) do
         {


### PR DESCRIPTION
### Background
Currently creating spy functionality that needs handlers for when a slack message is deleted and when a message is edited. Right now, `lita-slack` ignores events that are message deleted/changed events. 

### Changes
This PR allows the `message_deleted` and `message_changed` message subtypes to be handled as well as creating a `message_deleted` and `message_changed` trigger (like the `slack_reaction_added` or `slack_reaction_removed` trigger). These triggers are triggered when a message is deleted or changed.