### PR TITLE
 Phase 2 of conversations API 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 *.gem
 *.rbc
+.byebug_history
 .bundle
 .config
 .yardoc

--- a/lib/lita/adapters/slack/api.rb
+++ b/lib/lita/adapters/slack/api.rb
@@ -36,15 +36,21 @@ module Lita
         end
 
         def groups_list
-          conversations_list(types: ["private_channel"])
+          response = conversations_list(types: ["private_channel"])
+          response['groups'] = response['channels']
+          response
         end
 
         def mpim_list
-          conversations_list(types: ["mpim"])
+          response = conversations_list(types: ["mpim"])
+          response['groups'] = response['channels']
+          response
         end
 
-        def im_list #im
-          call_api("im.list")
+        def im_list
+          response = conversations_list(types: ["im"])
+          response['ims'] = response['channels']
+          response
         end
 
         def conversations_list(types: ["public_channel"], page_limit: nil)

--- a/lib/lita/adapters/slack/api.rb
+++ b/lib/lita/adapters/slack/api.rb
@@ -39,8 +39,8 @@ module Lita
           conversations_list(types: ["private_channel"])
         end
 
-        def mpim_list #mpim
-          call_api("mpim.list")
+        def mpim_list
+          conversations_list(types: ["mpim"])
         end
 
         def im_list #im

--- a/lib/lita/adapters/slack/api.rb
+++ b/lib/lita/adapters/slack/api.rb
@@ -35,8 +35,8 @@ module Lita
           conversations_list(types: ["public_channel"])
         end
 
-        def groups_list #private_channel
-          call_api("groups.list")
+        def groups_list
+          conversations_list(types: ["private_channel"])
         end
 
         def mpim_list #mpim

--- a/lib/lita/adapters/slack/api.rb
+++ b/lib/lita/adapters/slack/api.rb
@@ -32,18 +32,18 @@ module Lita
         end
 
         def channels_list
-          call_api("channels.list")
+          conversations_list(types: ["public_channel"])
         end
 
-        def groups_list
+        def groups_list #private_channel
           call_api("groups.list")
         end
 
-        def mpim_list
+        def mpim_list #mpim
           call_api("mpim.list")
         end
 
-        def im_list
+        def im_list #im
           call_api("im.list")
         end
 

--- a/spec/lita/adapters/slack/api_spec.rb
+++ b/spec/lita/adapters/slack/api_spec.rb
@@ -124,7 +124,7 @@ describe Lita::Adapters::Slack::API do
     let(:channel_id) { 'C024BE91L' }
     let(:stubs) do
       Faraday::Adapter::Test::Stubs.new do |stub|
-        stub.post('https://slack.com/api/channels.list', token: token) do
+        stub.post('https://slack.com/api/conversations.list', token: token, limit: nil, types: "public_channel") do
           [http_status, {}, http_response]
         end
       end
@@ -157,7 +157,7 @@ describe Lita::Adapters::Slack::API do
 
       it "raises a RuntimeError" do
         expect { subject.channels_list }.to raise_error(
-          "Slack API call to channels.list returned an error: invalid_auth."
+          "Slack API call to conversations.list returned an error: invalid_auth."
         )
       end
     end
@@ -168,7 +168,7 @@ describe Lita::Adapters::Slack::API do
 
       it "raises a RuntimeError" do
         expect { subject.channels_list }.to raise_error(
-          "Slack API call to channels.list failed with status code 422: ''. Headers: {}"
+          "Slack API call to conversations.list failed with status code 422: ''. Headers: {}"
         )
       end
     end

--- a/spec/lita/adapters/slack/api_spec.rb
+++ b/spec/lita/adapters/slack/api_spec.rb
@@ -232,7 +232,7 @@ describe Lita::Adapters::Slack::API do
     let(:channel_id) { 'G024BE91L' }
     let(:stubs) do
       Faraday::Adapter::Test::Stubs.new do |stub|
-        stub.post('https://slack.com/api/mpim.list', token: token) do
+        stub.post('https://slack.com/api/conversations.list', token: token, limit: nil, types: 'mpim') do
           [http_status, {}, http_response]
         end
       end
@@ -265,7 +265,7 @@ describe Lita::Adapters::Slack::API do
 
       it "raises a RuntimeError" do
         expect { subject.mpim_list }.to raise_error(
-          "Slack API call to mpim.list returned an error: invalid_auth."
+          "Slack API call to conversations.list returned an error: invalid_auth."
         )
       end
     end
@@ -276,7 +276,7 @@ describe Lita::Adapters::Slack::API do
 
       it "raises a RuntimeError" do
         expect { subject.mpim_list }.to raise_error(
-          "Slack API call to mpim.list failed with status code 422: ''. Headers: {}"
+          "Slack API call to conversations.list failed with status code 422: ''. Headers: {}"
         )
       end
     end

--- a/spec/lita/adapters/slack/api_spec.rb
+++ b/spec/lita/adapters/slack/api_spec.rb
@@ -124,7 +124,7 @@ describe Lita::Adapters::Slack::API do
     let(:channel_id) { 'C024BE91L' }
     let(:stubs) do
       Faraday::Adapter::Test::Stubs.new do |stub|
-        stub.post('https://slack.com/api/conversations.list', token: token, limit: nil, types: "public_channel") do
+        stub.post('https://slack.com/api/conversations.list', token: token, limit: nil, types: 'public_channel') do
           [http_status, {}, http_response]
         end
       end
@@ -178,7 +178,7 @@ describe Lita::Adapters::Slack::API do
     let(:channel_id) { 'G024BE91L' }
     let(:stubs) do
       Faraday::Adapter::Test::Stubs.new do |stub|
-        stub.post('https://slack.com/api/groups.list', token: token) do
+        stub.post('https://slack.com/api/conversations.list', token: token, limit: nil, types: 'private_channel') do
           [http_status, {}, http_response]
         end
       end
@@ -211,7 +211,7 @@ describe Lita::Adapters::Slack::API do
 
       it "raises a RuntimeError" do
         expect { subject.groups_list }.to raise_error(
-          "Slack API call to groups.list returned an error: invalid_auth."
+          "Slack API call to conversations.list returned an error: invalid_auth."
         )
       end
     end
@@ -222,7 +222,7 @@ describe Lita::Adapters::Slack::API do
 
       it "raises a RuntimeError" do
         expect { subject.groups_list }.to raise_error(
-          "Slack API call to groups.list failed with status code 422: ''. Headers: {}"
+          "Slack API call to conversations.list failed with status code 422: ''. Headers: {}"
         )
       end
     end

--- a/spec/lita/adapters/slack/api_spec.rb
+++ b/spec/lita/adapters/slack/api_spec.rb
@@ -134,7 +134,7 @@ describe Lita::Adapters::Slack::API do
       let(:http_response) do
         MultiJson.dump({
             ok: true,
-            channel: [{
+            channels: [{
                 id: 'C024BE91L'
             }]
         })
@@ -143,7 +143,7 @@ describe Lita::Adapters::Slack::API do
       it "returns a response with the Channel's ID" do
         response = subject.channels_list
 
-        expect(response['channel'].first['id']).to eq(channel_id)
+        expect(response['channels'].first['id']).to eq(channel_id)
       end
     end
 
@@ -188,7 +188,7 @@ describe Lita::Adapters::Slack::API do
       let(:http_response) do
         MultiJson.dump({
             ok: true,
-            groups: [{
+            channels: [{
                 id: 'G024BE91L'
             }]
         })
@@ -242,7 +242,7 @@ describe Lita::Adapters::Slack::API do
       let(:http_response) do
         MultiJson.dump({
             ok: true,
-            groups: [{
+            channels: [{
                 id: 'G024BE91L'
             }]
         })
@@ -286,7 +286,7 @@ describe Lita::Adapters::Slack::API do
     let(:channel_id) { 'D024BFF1M' }
     let(:stubs) do
       Faraday::Adapter::Test::Stubs.new do |stub|
-        stub.post('https://slack.com/api/im.list', token: token) do
+        stub.post('https://slack.com/api/conversations.list', token: token, limit: nil, types: 'im') do
           [http_status, {}, http_response]
         end
       end
@@ -296,7 +296,7 @@ describe Lita::Adapters::Slack::API do
       let(:http_response) do
         MultiJson.dump({
             ok: true,
-            ims: [{
+            channels: [{
                 id: 'D024BFF1M'
             }]
         })
@@ -319,7 +319,7 @@ describe Lita::Adapters::Slack::API do
 
       it "raises a RuntimeError" do
         expect { subject.im_list }.to raise_error(
-          "Slack API call to im.list returned an error: invalid_auth."
+          "Slack API call to conversations.list returned an error: invalid_auth."
         )
       end
     end
@@ -330,7 +330,7 @@ describe Lita::Adapters::Slack::API do
 
       it "raises a RuntimeError" do
         expect { subject.im_list }.to raise_error(
-          "Slack API call to im.list failed with status code 422: ''. Headers: {}"
+          "Slack API call to conversations.list failed with status code 422: ''. Headers: {}"
         )
       end
     end

--- a/spec/lita/adapters/slack_spec.rb
+++ b/spec/lita/adapters/slack_spec.rb
@@ -74,12 +74,6 @@ describe Lita::Adapters::Slack, lita: true do
 
     describe "via the Web API, retrieving the roster for a group/mpim channel" do
       let(:room_source) { Lita::Source.new(room: 'G024BE91L') }
-      let(:response) do
-        {
-          ok: true,
-          groups: [{ id: 'G024BE91L' }]
-        }
-      end
       let(:api) { instance_double('Lita::Adapters::Slack::API') }
 
       before do
@@ -96,12 +90,6 @@ describe Lita::Adapters::Slack, lita: true do
 
     describe "via the Web API, retrieving the roster for an im channel" do
       let(:room_source) { Lita::Source.new(room: 'D024BFF1M') }
-      let(:response) do
-        {
-          ok: true,
-          ims: [{ id: 'D024BFF1M' }]
-        }
-      end
       let(:api) { instance_double('Lita::Adapters::Slack::API') }
 
       before do


### PR DESCRIPTION
This hooks up the channels/groups/mpim/im list methods to the new conversations API, but makes them backwards compatible by copying the response to the original Key (copy, not reference)