### PR TITLE
Allow the various _list api methods to take parameters that get passed to the conversation API

### DIFF
--- a/lib/lita/adapters/slack/api.rb
+++ b/lib/lita/adapters/slack/api.rb
@@ -31,33 +31,33 @@ module Lita
           call_api("channels.info", channel: channel_id)
         end
 
-        def channels_list
-          conversations_list(types: ["public_channel"])
+        def channels_list(params: {})
+          conversations_list(types: ["public_channel"], params: params)
         end
 
-        def groups_list
-          response = conversations_list(types: ["private_channel"])
+        def groups_list(params: {})
+          response = conversations_list(types: ["private_channel"], params: params)
           response['groups'] = response['channels']
           response
         end
 
-        def mpim_list
-          response = conversations_list(types: ["mpim"])
+        def mpim_list(params: {})
+          response = conversations_list(types: ["mpim"], params: params)
           response['groups'] = response['channels']
           response
         end
 
-        def im_list
-          response = conversations_list(types: ["im"])
+        def im_list(params: {})
+          response = conversations_list(types: ["im"], params: params)
           response['ims'] = response['channels']
           response
         end
 
-        def conversations_list(types: ["public_channel"], page_limit: nil)
-          api_params = {
+        def conversations_list(types: ["public_channel"], page_limit: nil, params: {})
+          api_params = params.merge({
             limit: page_limit,
             types: types.join(",")
-          }
+          })
 
           result = call_api(
             "conversations.list",

--- a/spec/lita/adapters/slack/api_spec.rb
+++ b/spec/lita/adapters/slack/api_spec.rb
@@ -147,6 +147,31 @@ describe Lita::Adapters::Slack::API do
       end
     end
 
+    describe "with parameters" do
+      let(:stubs) do
+        Faraday::Adapter::Test::Stubs.new do |stub|
+          stub.post('https://slack.com/api/conversations.list', token: token, limit: nil, types: 'public_channel', exclude_archived: true) do
+            [http_status, {}, http_response]
+          end
+        end
+      end
+      let(:http_response) do
+        MultiJson.dump({
+            ok: true,
+            channels: [{
+                id: 'C024BE91L',
+                is_archived: false,
+            }]
+        })
+      end
+
+      it "returns a response with the Channel's ID" do
+        response = subject.channels_list(params: { exclude_archived: true })
+
+        expect(response['channels'].first['id']).to eq(channel_id)
+      end
+    end
+
     describe "with a Slack error" do
       let(:http_response) do
         MultiJson.dump({


### PR DESCRIPTION
In spy we're currently overridding `channels_list` in order to provide [API parameters](https://github.com/Shopify/spy/blob/43d05027ae84ef88acfedaff2ca663b34d129847/lib/spy/slack_api.rb#L40), this means we don't get the new API features & pagination but we need to move of these old APIs so adding an option to pass parameters that we merge with makes more sense

This isn't needed, but I feel it's more appropriate to use this API consistently