### PR TITLE
Fix the pagination to respect the retry after during rate limiting

### DIFF
--- a/spec/lita/adapters/slack/api_spec.rb
+++ b/spec/lita/adapters/slack/api_spec.rb
@@ -852,7 +852,7 @@ describe Lita::Adapters::Slack::API do
           stub.post('https://slack.com/api/conversations.list', token: token, limit: 1, types: "public_channel") do
             [http_status, {}, http_response]
           end
-          stub.post('https://slack.com/api/conversations.list', token: token, limit: 1, types: "public_channel", cursor: "dGVhbTpDMDI0RzRCR1k%3D") do
+          stub.post('https://slack.com/api/conversations.list', token: token, limit: 1, types: "public_channel", cursor: "dGVhbTpDMDI0RzRCR1k=") do
             [http_status, {}, http_response_2]
           end
         end


### PR DESCRIPTION
When implementing the pagination for conversations in Spy, I found we were being rate limited on the conversations API, so this adds handling in lita-slack to handle it, but I'm also overriding this in Spy, so it's not really needed unless someone needs it.

I'm frustrated with the silo dancing