### PR TITLE
Delegate Retry options to Faraday

### DIFF
--- a/lib/lita/adapters/slack/api.rb
+++ b/lib/lita/adapters/slack/api.rb
@@ -177,14 +177,22 @@ module Lita
 
         def connection
           if stubs
-            Faraday.new { |faraday| faraday.adapter(:test, stubs) }
+            retry_options = {
+              retry_statuses: [429],
+              methods: %i[get post]
+            }
+            @stub_connection ||= Faraday.new do |faraday|
+              faraday.request :retry, retry_options
+              faraday.adapter :test, stubs
+            end
           else
             options = {}
             unless config.proxy.nil?
               options = { proxy: config.proxy }
             end
             retry_options = {
-              retry_statuses: [429]
+              retry_statuses: [429],
+              methods: %i[get post]
             }
             Faraday.new(options) do |f|
               f.request :url_encoded


### PR DESCRIPTION
I discovered some bugs in the retry-after logic in lita-slack, this was written a while ago, and I found recently that Faraday can handle `retry-after` for us. (I refactored this out in [SpyV2](https://github.com/Shopify/spy-v2/pull/587/files) since The slack client we use there handles pagination)

This fixes those bugs so I can use them in Spy